### PR TITLE
Customization of the initial day of the week in KalendarKonfig

### DIFF
--- a/kalendar-endlos/src/main/java/com/himanshoe/kalendar/endlos/common/KalendarKonfig.kt
+++ b/kalendar-endlos/src/main/java/com/himanshoe/kalendar/endlos/common/KalendarKonfig.kt
@@ -37,5 +37,6 @@ data class KalendarKonfig(
     val maxYear: Int = 0,
     @IntRange(from = 1, to = 4)
     val weekCharacters: Int = 3,
-    val locale: Locale = Locale.ENGLISH
+    val locale: Locale = Locale.ENGLISH,
+    val isMondayInitialDay: Boolean = false
 )

--- a/kalendar-endlos/src/main/java/com/himanshoe/kalendar/endlos/ui/KalendarWeekDayNames.kt
+++ b/kalendar-endlos/src/main/java/com/himanshoe/kalendar/endlos/ui/KalendarWeekDayNames.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import com.himanshoe.kalendar.endlos.common.KalendarKonfig
+import com.himanshoe.kalendar.endlos.util.move
 import java.text.DateFormatSymbols
 
 private const val DAYS_IN_WEEK = 7
@@ -43,7 +44,9 @@ private const val ZERO = 0
 
 @Composable
 internal fun KalendarWeekDayNames(kalendarKonfig: KalendarKonfig) {
-    val weekdays = DateFormatSymbols(kalendarKonfig.locale).weekdays.takeLast(DAYS_IN_WEEK)
+
+    val weekdays = DateFormatSymbols(kalendarKonfig.locale).weekdays.takeLast(DAYS_IN_WEEK).toMutableList()
+    if (kalendarKonfig.isMondayInitialDay) weekdays.move(weekdays.first(), 6)
 
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
         val width = (maxWidth / DAYS_IN_WEEK)

--- a/kalendar-endlos/src/main/java/com/himanshoe/kalendar/endlos/util/Ext.kt
+++ b/kalendar-endlos/src/main/java/com/himanshoe/kalendar/endlos/util/Ext.kt
@@ -38,3 +38,10 @@ internal fun Int.validateMinDate(year: Int): Boolean {
         year < this
     }
 }
+
+fun <T> MutableList<T>.move(item: T, newIndex: Int)  {
+    val currentIndex = indexOf(item)
+    if (currentIndex < 0) return
+    removeAt(currentIndex)
+    add(newIndex, item)
+}

--- a/kalendar/src/main/java/com/himanshoe/kalendar/common/KalendarKonfig.kt
+++ b/kalendar/src/main/java/com/himanshoe/kalendar/common/KalendarKonfig.kt
@@ -38,6 +38,7 @@ data class KalendarKonfig(
     @IntRange(from = 1, to = 4)
     val weekCharacters: Int = 3,
     val locale: Locale = Locale.ENGLISH,
+    val isMondayInitialDay: Boolean = false
 )
 
 /**

--- a/kalendar/src/main/java/com/himanshoe/kalendar/ui/common/KalendarWeekDayNames.kt
+++ b/kalendar/src/main/java/com/himanshoe/kalendar/ui/common/KalendarWeekDayNames.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import com.himanshoe.kalendar.common.KalendarKonfig
+import com.himanshoe.kalendar.util.move
 import java.text.DateFormatSymbols
 
 private const val DAYS_IN_WEEK = 7
@@ -43,7 +44,9 @@ private const val ZERO = 0
 
 @Composable
 internal fun KalendarWeekDayNames(kalendarKonfig: KalendarKonfig) {
-    val weekdays = DateFormatSymbols(kalendarKonfig.locale).weekdays.takeLast(DAYS_IN_WEEK)
+
+    val weekdays = DateFormatSymbols(kalendarKonfig.locale).weekdays.takeLast(DAYS_IN_WEEK).toMutableList()
+    if (kalendarKonfig.isMondayInitialDay) weekdays.move(weekdays.first(), 6)
 
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
         val width = (maxWidth / DAYS_IN_WEEK)

--- a/kalendar/src/main/java/com/himanshoe/kalendar/util/Ext.kt
+++ b/kalendar/src/main/java/com/himanshoe/kalendar/util/Ext.kt
@@ -38,3 +38,10 @@ internal fun Int.validateMinDate(year: Int): Boolean {
         year < this
     }
 }
+
+fun <T> MutableList<T>.move(item: T, newIndex: Int)  {
+    val currentIndex = indexOf(item)
+    if (currentIndex < 0) return
+    removeAt(currentIndex)
+    add(newIndex, item)
+}


### PR DESCRIPTION
A new parameter called `isMondayInitialDay` of type Boolean is included in **KalendarKonfig**, in which we can indicate if the first day of the week is Monday (if true) and if not, the initial day would be Sunday