### PR TITLE
Date and Day name mismatch in Firey calendar type.

### DIFF
--- a/kalendar/src/main/java/com/himanshoe/kalendar/ui/firey/KalendarFirey.kt
+++ b/kalendar/src/main/java/com/himanshoe/kalendar/ui/firey/KalendarFirey.kt
@@ -93,7 +93,7 @@ internal fun KalendarFirey(
     onErrorRangeSelected: (RangeSelectionError) -> Unit = {}
 ) {
     val today = currentDay ?: Clock.System.todayIn(TimeZone.currentSystemDefault())
-    val weekValue = remember { mutableStateOf(today.getNext7Dates()) }
+   // val weekValue = remember { mutableStateOf(today.getNext7Dates()) }
     val selectedRange = remember { mutableStateOf<KalendarSelectedDayRange?>(null) }
     val selectedDate = remember { mutableStateOf(today) }
     val displayedMonth = remember { mutableStateOf(today.month) }
@@ -144,7 +144,7 @@ internal fun KalendarFirey(
             columns = GridCells.Fixed(7),
             content = {
                 if (showLabel) {
-                    items(weekValue.value) { item ->
+                    items(DayOfWeek.values()) { item ->
                         Text(
                             modifier = Modifier,
                             color = kalendarDayKonfig.textColor,


### PR DESCRIPTION
fixed date and day name mismatch in Firey calendar type.

![Screenshot_1](https://github.com/hi-manshu/Kalendar/assets/154777238/ec1d20cd-4a66-4826-9677-2fb4759b8fdd)
![Screenshot_4](https://github.com/hi-manshu/Kalendar/assets/154777238/a00d50c8-ea6d-4496-a3b5-187edbb8dfbb)
