### PR TITLE
fixed date and day-name mismatch in Firey calendar type.

### DIFF
--- a/kalendar/src/main/java/com/himanshoe/kalendar/ui/firey/KalendarFirey.kt
+++ b/kalendar/src/main/java/com/himanshoe/kalendar/ui/firey/KalendarFirey.kt
@@ -149,7 +149,7 @@ internal fun KalendarFirey(
                             modifier = Modifier,
                             color = kalendarDayKonfig.textColor,
                             fontSize = kalendarDayKonfig.textSize,
-                            text = labelFormat(item.dayOfWeek),
+                            text = labelFormat(item),
                             fontWeight = FontWeight.SemiBold,
                             textAlign = TextAlign.Center
                         )


### PR DESCRIPTION
fixed date and day-name mismatch in Firey calendar type.

![Screenshot_1](https://github.com/hi-manshu/Kalendar/assets/154777238/77326031-a4eb-4ebc-a368-85593d5ba365)
![Screenshot_4](https://github.com/hi-manshu/Kalendar/assets/154777238/fc13b97d-17a7-4035-821a-11da05a33281)
