### PR TITLE
Fix day selection mode in KalendarEndlos

### DIFF
--- a/kalendar-endlos/src/main/java/com/himanshoe/kalendar/endlos/util/DayClick.kt
+++ b/kalendar-endlos/src/main/java/com/himanshoe/kalendar/endlos/util/DayClick.kt
@@ -16,6 +16,7 @@ package com.himanshoe.kalendar.endlos.util
 
 import androidx.compose.runtime.MutableState
 import com.himanshoe.kalendar.endlos.DaySelectionMode
+import com.himanshoe.kalendar.endlos.RangeSelectionError
 import com.himanshoe.kalendar.endlos.daterange.KalendarSelectedDayRange
 import com.himanshoe.kalendar.endlos.model.KalendarEvent
 import kotlinx.datetime.LocalDate
@@ -29,6 +30,7 @@ import kotlinx.datetime.LocalDate
  * @param selectedRange The state holding the selected day range.
  * @param onRangeSelected Callback invoked when a range of days is selected.
  * @param onDayClick Callback invoked when a day is clicked.
+ * @param onErrorRangeSelected Callback invoked when an error occurs during range selection.
  */
 internal fun onDayClicked(
     date: LocalDate,
@@ -36,7 +38,8 @@ internal fun onDayClicked(
     daySelectionMode: DaySelectionMode,
     selectedRange: MutableState<KalendarSelectedDayRange?>,
     onRangeSelected: (KalendarSelectedDayRange, List<KalendarEvent>) -> Unit = { _, _ -> },
-    onDayClick: (LocalDate, List<KalendarEvent>) -> Unit = { _, _ -> }
+    onDayClick: (LocalDate, List<KalendarEvent>) -> Unit = { _, _ -> },
+    onErrorRangeSelected: (RangeSelectionError) -> Unit = {}
 ) {
     when (daySelectionMode) {
         DaySelectionMode.Single -> {
@@ -52,11 +55,15 @@ internal fun onDayClicked(
             }
 
             selectedRange.value?.let { rangeDates ->
-                val selectedEvents = events
-                    .filter { it.date in (rangeDates.start..rangeDates.end) }
-                    .toList()
+                if (rangeDates.end < rangeDates.start) {
+                    onErrorRangeSelected(RangeSelectionError.EndIsBeforeStart)
+                } else {
+                    val selectedEvents = events
+                        .filter { it.date in (rangeDates.start..rangeDates.end) }
+                        .toList()
 
-                onRangeSelected(rangeDates, selectedEvents)
+                    onRangeSelected(rangeDates, selectedEvents)
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #172

Add handling for `RangeSelectionError.EndIsBeforeStart` in `onDayClicked` function.

* **Import RangeSelectionError**
  - Import `RangeSelectionError` in `kalendar-endlos/src/main/java/com/himanshoe/kalendar/endlos/util/DayClick.kt`.

* **Add onErrorRangeSelected parameter**
  - Add `onErrorRangeSelected` parameter to `onDayClicked` function.

* **Handle end date before start date**
  - Add a condition to trigger `onErrorRangeSelected(RangeSelectionError.EndIsBeforeStart)` when the end date is before the start date.

