### PR TITLE
Send events only for selected day & refactor KalendarEvent

### DIFF
--- a/kalendar-foundation/src/commonMain/kotlin/com/himanshoe/kalendar/foundation/action/OnDayClick.kt
+++ b/kalendar-foundation/src/commonMain/kotlin/com/himanshoe/kalendar/foundation/action/OnDayClick.kt
@@ -16,11 +16,11 @@
 
 package com.himanshoe.kalendar.foundation.action
 
-import com.himanshoe.kalendar.foundation.event.KalendarEvent
+import com.himanshoe.kalendar.foundation.event.KalenderEvent
 import kotlinx.datetime.LocalDate
 
 fun LocalDate.onDayClick(
-    events: List<KalendarEvent>,
+    events: List<KalenderEvent>,
     rangeStartDate: LocalDate?,
     rangeEndDate: LocalDate?,
     onDaySelectionAction: OnDaySelectionAction,

--- a/kalendar-foundation/src/commonMain/kotlin/com/himanshoe/kalendar/foundation/action/OnDaySelectionAction.kt
+++ b/kalendar-foundation/src/commonMain/kotlin/com/himanshoe/kalendar/foundation/action/OnDaySelectionAction.kt
@@ -16,13 +16,13 @@
 
 package com.himanshoe.kalendar.foundation.action
 
-import com.himanshoe.kalendar.foundation.event.KalendarEvent
+import com.himanshoe.kalendar.foundation.event.KalenderEvent
 import kotlinx.datetime.LocalDate
 
 sealed class OnDaySelectionAction {
-    data class Single(val onDayClick: (LocalDate, List<KalendarEvent>) -> Unit) :
+    data class Single(val onDayClick: (LocalDate, List<KalenderEvent>) -> Unit) :
         OnDaySelectionAction()
 
-    data class Range(val onRangeSelected: (KalendarSelectedDayRange, List<KalendarEvent>) -> Unit) :
+    data class Range(val onRangeSelected: (KalendarSelectedDayRange, List<KalenderEvent>) -> Unit) :
         OnDaySelectionAction()
 }

--- a/kalendar-foundation/src/commonMain/kotlin/com/himanshoe/kalendar/foundation/component/KalendarDay.kt
+++ b/kalendar-foundation/src/commonMain/kotlin/com/himanshoe/kalendar/foundation/component/KalendarDay.kt
@@ -41,8 +41,8 @@ import androidx.compose.ui.util.fastFilter
 import androidx.compose.ui.util.fastForEachIndexed
 import com.himanshoe.kalendar.foundation.action.KalendarSelectedDayRange
 import com.himanshoe.kalendar.foundation.component.config.KalendarDayKonfig
-import com.himanshoe.kalendar.foundation.event.KalendarEvent
 import com.himanshoe.kalendar.foundation.event.KalendarEvents
+import com.himanshoe.kalendar.foundation.event.KalenderEvent
 import com.himanshoe.kalendar.foundation.ext.circleLayout
 import com.himanshoe.kalendar.foundation.ext.dayBackgroundColor
 import kotlinx.datetime.Clock
@@ -58,7 +58,7 @@ fun KalendarDay(
     selectedDate: LocalDate = date,
     events: KalendarEvents = KalendarEvents(),
     dayKonfig: KalendarDayKonfig = KalendarDayKonfig.default(),
-    onDayClick: (LocalDate, List<KalendarEvent>) -> Unit = { _, _ -> },
+    onDayClick: (LocalDate, List<KalenderEvent>) -> Unit = { _, _ -> },
 ) {
     KalendarDayContent(
         date = date,
@@ -79,7 +79,7 @@ private fun KalendarDayContent(
     selectedDate: LocalDate = date,
     dayKonfig: KalendarDayKonfig = KalendarDayKonfig.default(),
     events: KalendarEvents = KalendarEvents(),
-    onDayClick: (LocalDate, List<KalendarEvent>) -> Unit = { _, _ -> }
+    onDayClick: (LocalDate, List<KalenderEvent>) -> Unit = { _, _ -> }
 ) {
     val today = remember(TimeZone.currentSystemDefault()) {
         Clock.System.todayIn(TimeZone.currentSystemDefault())
@@ -108,7 +108,9 @@ private fun KalendarDayContent(
                 selectedRange = selectedRange,
                 colors = dayKonfig.selectedBackgroundColor.value
             )
-            .clickable { onDayClick(date, events.eventList) }
+            .clickable {
+                onDayClick(date, currentDayEvents)
+            }
             .circleLayout()
             .defaultMinSize(dayKonfig.size),
         verticalArrangement = Arrangement.Center,
@@ -135,7 +137,7 @@ private fun KalendarDayContent(
 
 @Composable
 private fun EventIndicators(
-    events: List<KalendarEvent>,
+    events: List<KalenderEvent>,
     dayKonfig: KalendarDayKonfig,
     modifier: Modifier = Modifier
 ) {

--- a/kalendar-foundation/src/commonMain/kotlin/com/himanshoe/kalendar/foundation/event/KalendarEvent.kt
+++ b/kalendar-foundation/src/commonMain/kotlin/com/himanshoe/kalendar/foundation/event/KalendarEvent.kt
@@ -18,12 +18,44 @@ package com.himanshoe.kalendar.foundation.event
 
 import kotlinx.datetime.LocalDate
 
-data class KalendarEvent(
-    val date: LocalDate,
-    val eventName: String,
-    val eventDescription: String? = null
-)
+/**
+ * Represents an event in the calendar.
+ */
+interface KalenderEvent {
+    /**
+     * The date of the event.
+     */
+    val date: LocalDate
 
+    /**
+     * The name of the event.
+     */
+    val eventName: String
+
+    /**
+     * The description of the event.
+     */
+    val eventDescription: String?
+}
+
+/**
+ * A basic implementation of the [KalenderEvent] interface.
+ *
+ * @property date The date of the event.
+ * @property eventName The name of the event.
+ * @property eventDescription The description of the event.
+ */
+data class BasicKalendarEvent(
+    override val date: LocalDate,
+    override val eventName: String,
+    override val eventDescription: String?
+) : KalenderEvent
+
+/**
+ * A collection of calendar events.
+ *
+ * @property eventList The list of events.
+ */
 data class KalendarEvents(
-    val eventList: List<KalendarEvent> = emptyList()
+    val eventList: List<KalenderEvent> = emptyList()
 )

--- a/kalendar/src/commonMain/kotlin/com/himanshoe/kalendar/KalendarAerial.kt
+++ b/kalendar/src/commonMain/kotlin/com/himanshoe/kalendar/KalendarAerial.kt
@@ -44,6 +44,7 @@ import com.himanshoe.kalendar.foundation.component.config.KalendarDayLabelKonfig
 import com.himanshoe.kalendar.foundation.component.config.KalendarHeaderKonfig
 import com.himanshoe.kalendar.foundation.component.config.KalendarKonfig
 import com.himanshoe.kalendar.foundation.event.KalendarEvents
+import com.himanshoe.kalendar.foundation.event.KalenderEvent
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
@@ -159,7 +160,7 @@ private fun KalendarAerialContent(
                 KalendarDay(
                     date = date,
                     selectedRange = selectedRange.value,
-                    onDayClick = { clickedDate, events ->
+                    onDayClick = { clickedDate, events: List<KalenderEvent> ->
                         clickedDate.onDayClick(
                             events = events,
                             rangeStartDate = rangeStartDate,

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -15,7 +15,6 @@
  */
 
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
@@ -77,6 +76,8 @@ kotlin {
             implementation(compose.foundation)
             implementation(project(":kalendar"))
             implementation(project(":kalendar-foundation"))
+//            implementation("com.himanshoe:kalendar:2.0.0-RC1")
+//            implementation("com.himanshoe:kalendar-foundation:1.0.0")
             implementation(compose.material)
             implementation(compose.ui)
             implementation(libs.kotlinx.datetime)

--- a/sample/src/commonMain/kotlin/com/himanshoe/sample/App.kt
+++ b/sample/src/commonMain/kotlin/com/himanshoe/sample/App.kt
@@ -19,27 +19,26 @@ package com.himanshoe.sample
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import com.himanshoe.kalendar.Kalendar
 import com.himanshoe.kalendar.KalendarType
 import com.himanshoe.kalendar.foundation.action.OnDaySelectionAction
 import com.himanshoe.kalendar.foundation.event.KalendarEvents
+import com.himanshoe.kalendar.foundation.event.KalenderEvent
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.todayIn
 
 @Composable
 fun App() {
     Column(modifier = Modifier.wrapContentSize().background(Color.Blue)) {
-//        Kalendar(
+        //        Kalendar(
 //            selectedDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
 //            modifier = Modifier.fillMaxWidth(),
 //            events = KalendarEvents(),
@@ -73,13 +72,35 @@ fun App() {
 //        )
 //        Spacer(Modifier.height(16.dp))
 //
+        data class TestEvent(
+            override val date: LocalDate,
+            override val eventName: String,
+            override val eventDescription: String?,
+            val test: String
+        ) : KalenderEvent
+
         Kalendar(
             selectedDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
             modifier = Modifier.fillMaxWidth(),
-            events = KalendarEvents(),
+            events = KalendarEvents(
+                eventList = listOf(
+                    TestEvent(
+                        date = Clock.System.todayIn(TimeZone.currentSystemDefault()),
+                        eventName = "Event 1",
+                        eventDescription = "Event 1 Description",
+                        test = "Event 1 Description",
+                    ),
+                    TestEvent(
+                        date = Clock.System.todayIn(TimeZone.currentSystemDefault()),
+                        eventName = "Event 1",
+                        eventDescription = "Event 1 Description",
+                        test = "Event 1 Description"
+                    )
+                )
+            ),
             startDayOfWeek = DayOfWeek.MONDAY,
             kalendarType = KalendarType.Aerial,
-            onDaySelectionAction = OnDaySelectionAction.Range { date, events ->
+            onDaySelectionAction = OnDaySelectionAction.Single { date, events ->
                 println("Selected Date: $date with events: $events")
             },
         )


### PR DESCRIPTION
- Events are now sent only for the specific day that is clicked.
- Refactored `KalendarEvent` into an interface for better flexibility:

Details:
https://github.com/hi-manshu/Kalendar/issues/184